### PR TITLE
build(wrangler): update compatibility date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "cdn"
 main = "src/index.ts"
-compatibility_date = "2023-03-07"
+compatibility_date = "2026-07-05"
 send_metrics = false
 
 account_id = "3d314ce955c4f69056e1f4b64842fd55"


### PR DESCRIPTION
Updates the wrangler compatibility date from 2023 to 2026. However, because this contains 3 years of changes, the CDN needs testing before this PR is merged.